### PR TITLE
Prevent race condition when creating the storage directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,20 @@ language: php
 matrix:
   include:
   - php: "7.0"
-    env: LARAVEL_VERSION="5.5.*"
+    env: LARAVEL_VERSION="5.5.*" TESTBENCH_VERSION="3.5.*"
   - php: "7.1"
-    env: LARAVEL_VERSION="5.5.*"
+    env: LARAVEL_VERSION="5.5.*" TESTBENCH_VERSION="3.5.*"
   - php: "7.2"
-    env: LARAVEL_VERSION="5.5.*"
+    env: LARAVEL_VERSION="5.5.*" TESTBENCH_VERSION="3.5.*"
   - php: "7.2"
-    env: LARAVEL_VERSION="5.6.*"
+    env: LARAVEL_VERSION="5.6.*" TESTBENCH_VERSION="3.6.*"
   - php: "7.2"
-    env: LARAVEL_VERSION="5.7.*" RUN_CS_FIXER=1
+    env: LARAVEL_VERSION="5.7.*" TESTBENCH_VERSION="3.7.*" RUN_CS_FIXER=1
 
 sudo: false
 
 install:
-  - composer require "illuminate/console:${LARAVEL_VERSION}" "illuminate/filesystem:${LARAVEL_VERSION}" "illuminate/http:${LARAVEL_VERSION}" "illuminate/routing:${LARAVEL_VERSION}" "illuminate/support:${LARAVEL_VERSION}" --no-update --no-interaction
+  - composer require "illuminate/console:${LARAVEL_VERSION}" "illuminate/filesystem:${LARAVEL_VERSION}" "illuminate/http:${LARAVEL_VERSION}" "illuminate/routing:${LARAVEL_VERSION}" "illuminate/support:${LARAVEL_VERSION}" "orchestra/testbench:${TESTBENCH_VERSION}" --no-update --no-interaction
   - travis_retry composer install --no-interaction --prefer-dist
 
 script:

--- a/src/StaticRequestCache.php
+++ b/src/StaticRequestCache.php
@@ -4,6 +4,7 @@ namespace Swis\LaravelStaticRequestCache;
 
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\Request;
+use RuntimeException;
 use Symfony\Component\HttpFoundation\Response;
 
 class StaticRequestCache
@@ -97,10 +98,12 @@ class StaticRequestCache
      */
     private function ensureStorageDirectory(string $filename)
     {
-        $path = dirname($filename);
+        $path = $this->files->dirname($filename);
+
+        $this->files->makeDirectory($path, 0777, true, true);
 
         if (!$this->files->isDirectory($path)) {
-            $this->files->makeDirectory($path, 0777, true);
+            throw new RuntimeException(sprintf('Directory "%s" could not be created', $path));
         }
     }
 

--- a/tests/StaticRequestCacheTest.php
+++ b/tests/StaticRequestCacheTest.php
@@ -169,6 +169,10 @@ class StaticRequestCacheTest extends \Orchestra\Testbench\TestCase
             ->method('put')
             ->with($this->publicDir.'/static/html/foo/bar/index.html', 'Lorem ipsum');
 
+        $filesystemMock
+            ->method('isDirectory')
+            ->willReturn(true);
+
         $staticRequestCache = new \Swis\LaravelStaticRequestCache\StaticRequestCache($filesystemMock);
         $staticRequestCache->store($request, $response);
     }
@@ -185,6 +189,29 @@ class StaticRequestCacheTest extends \Orchestra\Testbench\TestCase
             ->expects($this->once())
             ->method('put')
             ->with($this->publicDir.'/static/html/foo/bar.json', '{foo: "bar"}');
+
+        $filesystemMock
+            ->method('isDirectory')
+            ->willReturn(true);
+
+        $staticRequestCache = new \Swis\LaravelStaticRequestCache\StaticRequestCache($filesystemMock);
+        $staticRequestCache->store($request, $response);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testItThrowsWhenDirectoryCouldNotBeCreated()
+    {
+        $request = \Illuminate\Http\Request::create('foo/bar', 'GET');
+        $response = $this->getCacheablesResponse();
+        $response->setContent('Lorem ipsum');
+
+        $filesystemMock = $this->getFilesystemMock();
+
+        $filesystemMock
+            ->method('isDirectory')
+            ->willReturn(false);
 
         $staticRequestCache = new \Swis\LaravelStaticRequestCache\StaticRequestCache($filesystemMock);
         $staticRequestCache->store($request, $response);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I changed the logic in `\Swis\LaravelStaticRequestCache\StaticRequestCache::ensureStorageDirectory` to prevent race-conditions.

## Motivation and context

If you have multiple simultaneous requests, the old code could result in a race condition where multiple requests try to create the same directory. Please see https://github.com/kalessil/phpinspectionsea/blob/master/docs/probable-bugs.md#mkdir-race-condition for more information.

## How has this been tested?

Tested in a production application where the race condition occurred very often.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
