### PR TITLE
Do not cache URLs containing 'index.php'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## Unreleased
 
-* Nothing
+### Fixed
+* URLs containing `index.php` are not cached.
+N.B. This requires a change to your `.htaccess` file for a complete fix.
 
 ## [0.6.0] - 2019-03-29
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ protected $middleware = [
 
 Add the following snippet into your `.htaccess`
 ```apacheconfig
-# Rewrite to html cache if it exists and the request is off a static page
+# Rewrite to html cache if it exists and the request is for a static page
 # (no url query params and only get requests)
 RewriteCond %{REQUEST_METHOD} GET
 RewriteCond %{QUERY_STRING} !.*=.*
@@ -36,6 +36,7 @@ RewriteRule ^(.*)$  /static/html%{REQUEST_URI} [L]
 
 RewriteCond %{REQUEST_METHOD} GET
 RewriteCond %{QUERY_STRING} !.*=.*
+RewriteCond %{REQUEST_URI} !index.php
 RewriteCond %{DOCUMENT_ROOT}/static/html%{REQUEST_URI}/index.html -f
 RewriteRule ^(.*)$ /static/html%{REQUEST_URI}/index.html [L]
 ```

--- a/src/StaticRequestCache.php
+++ b/src/StaticRequestCache.php
@@ -4,6 +4,7 @@ namespace Swis\LaravelStaticRequestCache;
 
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -44,6 +45,7 @@ class StaticRequestCache
         $isGETRequest = $request->getMethod() === 'GET';
         $hasNoParams = count($request->input()) === 0;
         $contentTypeData = $this->getContentTypeFromResponse($response);
+        $hasIndexPhpInRequestUri = Str::contains($request->getRequestUri(), 'index.php');
 
         $isCachableMimeType = false;
         foreach ($contentTypeData as $contentType) {
@@ -67,6 +69,7 @@ class StaticRequestCache
         return $this->enabled
             && $response->isOk()
             && !$hasDisablingCacheHeaders
+            && !$hasIndexPhpInRequestUri
             && $isGETRequest
             && $hasNoParams
             && $isCachableMimeType;

--- a/tests/StaticRequestCacheTest.php
+++ b/tests/StaticRequestCacheTest.php
@@ -122,6 +122,15 @@ class StaticRequestCacheTest extends \Orchestra\Testbench\TestCase
         $this->assertFalse($staticRequestCache->shouldStoreResponse($request, $response));
     }
 
+    public function testRequestUriContainingIndexPhpIsNotCached()
+    {
+        $request = \Illuminate\Http\Request::create('index.php', 'GET');
+        $response = $this->getCacheablesResponse();
+
+        $staticRequestCache = new \Swis\LaravelStaticRequestCache\StaticRequestCache($this->getFilesystemMock());
+        $this->assertFalse($staticRequestCache->shouldStoreResponse($request, $response));
+    }
+
     public function testNonCacheableContentTypesIsNotCached()
     {
         $request = \Illuminate\Http\Request::create('', 'GET');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

URLs containing 'index.php' are not cached.

## Motivation and context

Previously, if a request was made to 'example.com/index.php' it was cached. But when it is cached, the `.htaccess` rule rewrites everything to this cached response making your entire application static... By excluding URLs containing 'index.php' and adding an extra check to the `.htaccess` rule, we can prevent this.

## How has this been tested?

Tested using new PHPUnit test and in a real application.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
