### PR TITLE
Throw custom exceptions

### DIFF
--- a/src/Exceptions/CacheException.php
+++ b/src/Exceptions/CacheException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Swis\Laravel\StaticRequestCache\Exceptions;
+
+use RuntimeException;
+
+class CacheException extends RuntimeException implements Exception
+{
+}

--- a/src/Exceptions/Exception.php
+++ b/src/Exceptions/Exception.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Swis\Laravel\StaticRequestCache\Exceptions;
+
+interface Exception
+{
+}

--- a/src/StaticRequestCache.php
+++ b/src/StaticRequestCache.php
@@ -5,7 +5,7 @@ namespace Swis\Laravel\StaticRequestCache;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
-use RuntimeException;
+use Swis\Laravel\StaticRequestCache\Exceptions\CacheException;
 use Symfony\Component\HttpFoundation\Response;
 
 class StaticRequestCache
@@ -108,7 +108,7 @@ class StaticRequestCache
         $this->files->makeDirectory($path, 0777, true, true);
 
         if (!$this->files->isDirectory($path)) {
-            throw new RuntimeException(sprintf('Directory "%s" could not be created', $path));
+            throw new CacheException(sprintf('Directory "%s" could not be created', $path));
         }
     }
 
@@ -147,6 +147,8 @@ class StaticRequestCache
 
         $file = $response->getContent();
 
-        $this->files->put($filename, $file);
+        if ($this->files->put($filename, $file) === false) {
+            throw new CacheException(sprintf('File "%s" could not be created', $filename));
+        }
     }
 }

--- a/tests/Http/Middleware/CacheMiddlewareTest.php
+++ b/tests/Http/Middleware/CacheMiddlewareTest.php
@@ -3,7 +3,7 @@
 namespace Swis\Laravel\StaticRequestCache\Tests\Http\Middleware;
 
 use Illuminate\Http\Request;
-use RuntimeException;
+use Swis\Laravel\StaticRequestCache\Exceptions\CacheException;
 use Swis\Laravel\StaticRequestCache\Http\Middleware\CacheMiddleware;
 use Swis\Laravel\StaticRequestCache\StaticRequestCache;
 use Symfony\Component\HttpFoundation\Response;
@@ -103,7 +103,7 @@ class CacheMiddlewareTest extends \Orchestra\Testbench\TestCase
         $staticRequestCache->expects($this->once())
             ->method('store')
             ->with($request, $response)
-            ->willThrowException(new RuntimeException('Directory "/test/" could not be created'));
+            ->willThrowException(new CacheException('Directory "/test/" could not be created'));
 
         $middleware = new CacheMiddleware($staticRequestCache);
         $middleware->terminate($request, $response);
@@ -111,7 +111,7 @@ class CacheMiddlewareTest extends \Orchestra\Testbench\TestCase
 
     public function testItThrowsWhenNotInGracefulMode()
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CacheException::class);
 
         $this->app['config']->set('static-html-cache.graceful', false);
 
@@ -132,7 +132,7 @@ class CacheMiddlewareTest extends \Orchestra\Testbench\TestCase
         $staticRequestCache->expects($this->once())
             ->method('store')
             ->with($request, $response)
-            ->willThrowException(new RuntimeException('Directory "/test/" could not be created'));
+            ->willThrowException(new CacheException('Directory "/test/" could not be created'));
 
         $middleware = new CacheMiddleware($staticRequestCache);
         $middleware->terminate($request, $response);

--- a/tests/StaticRequestCacheTest.php
+++ b/tests/StaticRequestCacheTest.php
@@ -2,7 +2,7 @@
 
 namespace Swis\Laravel\StaticRequestCache\Tests;
 
-use RuntimeException;
+use Swis\Laravel\StaticRequestCache\Exceptions\CacheException;
 
 class StaticRequestCacheTest extends \Orchestra\Testbench\TestCase
 {
@@ -211,7 +211,7 @@ class StaticRequestCacheTest extends \Orchestra\Testbench\TestCase
 
     public function testItThrowsWhenDirectoryCouldNotBeCreated()
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CacheException::class);
 
         $request = \Illuminate\Http\Request::create('foo/bar', 'GET');
         $response = $this->getCacheablesResponse();
@@ -221,6 +221,24 @@ class StaticRequestCacheTest extends \Orchestra\Testbench\TestCase
 
         $filesystemMock
             ->method('isDirectory')
+            ->willReturn(false);
+
+        $staticRequestCache = new \Swis\Laravel\StaticRequestCache\StaticRequestCache($filesystemMock);
+        $staticRequestCache->store($request, $response);
+    }
+
+    public function testItThrowsWhenFileCouldNotBeCreated()
+    {
+        $this->expectException(CacheException::class);
+
+        $request = \Illuminate\Http\Request::create('foo/bar', 'GET');
+        $response = $this->getCacheablesResponse();
+        $response->setContent('Lorem ipsum');
+
+        $filesystemMock = $this->getFilesystemMock();
+
+        $filesystemMock
+            ->method('put')
             ->willReturn(false);
 
         $staticRequestCache = new \Swis\Laravel\StaticRequestCache\StaticRequestCache($filesystemMock);


### PR DESCRIPTION
## Description

I replaced all thrown RuntimeExceptions with a custom exception. I now also throw an exception when the file could not be created and not only when the directory could not be created.

## Motivation and context

This allows the consumer to identify our exceptions and for example add these to the dontReport property of the exception handler. The new exception extends the `RuntimeException` to make it backwards compatible.

## How has this been tested?

Tested with existing (updated) unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
